### PR TITLE
# 49 debian upgrade

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # debian:11 = debian:bullseye
 # debian@sha256:4b48997afc712259da850373fdbc60315316ee72213a4e77fc5a66032d790b2a
-BASE_IMAGE=debian:11.8-slim
+BASE_IMAGE=debian:12.8-slim
 
 # alpine:3.18
 # alpine@sha256:d695c3de6fcd8cfe3a6222b0358425d40adfd129a8a47c3416faff1a8aece389

--- a/docs/release-notes/v1.5.0.adoc
+++ b/docs/release-notes/v1.5.0.adoc
@@ -3,6 +3,7 @@
 All images are 1:1 compatible with version 1.4.0.
 
 .Changes
-*The *icellmobilsoft/builder-nexus-download* builder image:
+* The *icellmobilsoft/builder-nexus-download* builder image:
 ** In the `sonatype-download.sh` script, the default value of the SONATYPE_REPOSITORY environment variable has been changed to `public`, allowing the Sonatype API to also find `-SNAPSHOT` versions.
 ** A new `DEBUG` variable has been added. In case of `true` it prints the issued commands to the terminal for easy debugging.  
+** Debian image upgrade: debian:11.8-slim -> debian:12.8-slim


### PR DESCRIPTION
- debian upgrade
- sec example by trivy, critical fixes, the example is a simple quarkus based on debian/jvm
[quarkus-debian12.8-slim.txt](https://github.com/user-attachments/files/18335084/quarkus-debian12.8-slim.txt)
[quarkus-debian11.8-slim.txt](https://github.com/user-attachments/files/18335085/quarkus-debian11.8-slim.txt)
