### PR TITLE
82 - jdk 21 version upgrade to 21.0.10

### DIFF
--- a/.env
+++ b/.env
@@ -10,8 +10,8 @@ JRE_11_TEMURIN_IMAGE=eclipse-temurin:11.0.29_7-jre
 JDK_11_TEMURIN_IMAGE=eclipse-temurin:11.0.29_7-jdk
 JRE_17_TEMURIN_IMAGE=eclipse-temurin:17.0.17_10-jre
 JDK_17_TEMURIN_IMAGE=eclipse-temurin:17.0.17_10-jdk
-JRE_21_TEMURIN_IMAGE=eclipse-temurin:21.0.10-jre
-JDK_21_TEMURIN_IMAGE=eclipse-temurin:21.0.10-jre
+JRE_21_TEMURIN_IMAGE=eclipse-temurin:21.0.10_7-jre
+JDK_21_TEMURIN_IMAGE=eclipse-temurin:21.0.10_7-jre
 
 GALLEON_VERSION=6.1.1.Final
 MAVEN_VERSION=3.9.12

--- a/.env
+++ b/.env
@@ -6,12 +6,12 @@ BASE_IMAGE=debian:12.12-slim
 # alpine@sha256:de0eb0b3f2a47ba1eb89389859a9bd88b28e82f5826b6969ad604979713c2d4f
 ALPINE_BASE_IMAGE=alpine:3.18.12
 
-JRE_11_TEMURIN_IMAGE=eclipse-temurin:11.0.29_7-jre
-JDK_11_TEMURIN_IMAGE=eclipse-temurin:11.0.29_7-jdk
-JRE_17_TEMURIN_IMAGE=eclipse-temurin:17.0.17_10-jre
-JDK_17_TEMURIN_IMAGE=eclipse-temurin:17.0.17_10-jdk
-JRE_21_TEMURIN_IMAGE=eclipse-temurin:21.0.10_7-jre
-JDK_21_TEMURIN_IMAGE=eclipse-temurin:21.0.10_7-jre
+JRE_11_TEMURIN_IMAGE=eclipse-temurin:11.0.31_11-jre
+JDK_11_TEMURIN_IMAGE=eclipse-temurin:11.0.31_11-jdk
+JRE_17_TEMURIN_IMAGE=eclipse-temurin:17.0.19_10-jre
+JDK_17_TEMURIN_IMAGE=eclipse-temurin:17.0.19_10-jdk
+JRE_21_TEMURIN_IMAGE=eclipse-temurin:21.0.11_10-jre
+JDK_21_TEMURIN_IMAGE=eclipse-temurin:21.0.11_10-jre
 
 GALLEON_VERSION=6.1.1.Final
 MAVEN_VERSION=3.9.12

--- a/.env
+++ b/.env
@@ -10,8 +10,8 @@ JRE_11_TEMURIN_IMAGE=eclipse-temurin:11.0.29_7-jre
 JDK_11_TEMURIN_IMAGE=eclipse-temurin:11.0.29_7-jdk
 JRE_17_TEMURIN_IMAGE=eclipse-temurin:17.0.17_10-jre
 JDK_17_TEMURIN_IMAGE=eclipse-temurin:17.0.17_10-jdk
-JRE_21_TEMURIN_IMAGE=eclipse-temurin:21.0.9_10-jre
-JDK_21_TEMURIN_IMAGE=eclipse-temurin:21.0.9_10-jre
+JRE_21_TEMURIN_IMAGE=eclipse-temurin:21.0.10-jre
+JDK_21_TEMURIN_IMAGE=eclipse-temurin:21.0.10-jre
 
 GALLEON_VERSION=6.1.1.Final
 MAVEN_VERSION=3.9.12

--- a/docs/release-notes/v1.9.0.adoc
+++ b/docs/release-notes/v1.9.0.adoc
@@ -1,0 +1,7 @@
+= v1.8.0
+
+All images are 1:1 compatible with version 1.8.0.
+
+.Changes
+* Upgrades:
+** `JRE` and `JDK` 21 `21.0.9_10` -> `21.0.10`

--- a/docs/release-notes/v1.9.0.adoc
+++ b/docs/release-notes/v1.9.0.adoc
@@ -4,4 +4,4 @@ All images are 1:1 compatible with version 1.8.0.
 
 .Changes
 * Upgrades:
-** `JRE` and `JDK` 21 `21.0.9_10` -> `21.0.10`
+** `JRE` and `JDK` 21 `21.0.9_10` -> `21.0.10_7`

--- a/docs/release-notes/v1.9.0.adoc
+++ b/docs/release-notes/v1.9.0.adoc
@@ -4,4 +4,6 @@ All images are 1:1 compatible with version 1.8.0.
 
 .Changes
 * Upgrades:
-** `JRE` and `JDK` 21 `21.0.9_10` -> `21.0.10_7`
+** `JRE` and `JDK` 11 `11.0.29_7` -> `11.0.31_11`
+** `JRE` and `JDK` 17 `17.0.17_10` -> `17.0.19_10`
+** `JRE` and `JDK` 21 `21.0.9_10` -> `21.0.11_10`

--- a/docs/release-notes/v1.9.0.adoc
+++ b/docs/release-notes/v1.9.0.adoc
@@ -1,4 +1,4 @@
-= v1.8.0
+= v1.9.0
 
 All images are 1:1 compatible with version 1.8.0.
 


### PR DESCRIPTION
A linkelt jdk bug alapján a 17es és 11es verziókba is bekerült a javítás, de még nem lettek releaselve azok a verziók.